### PR TITLE
Fix empty final ngram

### DIFF
--- a/quickumls.py
+++ b/quickumls.py
@@ -336,6 +336,10 @@ class QuickUMLS(object):
             for j in xrange(
                     i + 1, min(i + self.window, len(parsed)) + 1):
                 span = parsed[i:j]
+                
+                if not self._is_longer_than_min(span):
+                    continue
+                
                 yield (span.start_char, span.end_char, span.text)
 
     def _print_verbose_status(self, parsed, matches):

--- a/sample.py
+++ b/sample.py
@@ -1,0 +1,25 @@
+try:
+    from quickumls import QuickUMLS
+except ImportError:
+    from .quickumls import QuickUMLS
+
+print('Creating QuickUMLS object...')
+    
+quickumls_path = r'C:\quickumls'
+    
+matcher = QuickUMLS(quickumls_path)
+
+print('QuickUMLS object created...')
+
+text = "The ulna has dislocated posteriorly from the trochlea of the humerus."
+
+print('*************************')
+print('Text:')
+print(text)
+print('*************************')
+
+res = matcher.match(text, best_match=True, ignore_syntax=False)
+
+print('Matching results:')
+print(res)
+


### PR DESCRIPTION
When running with ignore_syntax=True I was often getting division by zero errors.  In tracking this back, the method that breaks up ngrams was not skipping tokens which were under the minimum length like is done in _make_ngrams.  Adding a check for this prevents the div-by-zero error.