### PR TITLE
Add option to disable lowercase conversion of all uppercase words.

### DIFF
--- a/quickumls/core.py
+++ b/quickumls/core.py
@@ -94,6 +94,13 @@ class QuickUMLS(object):
         )
         self.keep_uppercase = keep_uppercase
 
+        # Check whether data is installed with lowercase flag and QuickUMLS initiated with keeping uppercase words
+        if self.to_lowercase_flag and self.keep_uppercase:
+            raise ValueError('Database is installed with lowercase flag and QuickUMLS is initiated with '
+                             'keep_uppercase flag. This would prevent identifying concepts that contain all uppercase'
+                             'characters. Please reinstall data without --lowercase or run QuickUMLS without'
+                             '--keep_uppercase.')
+
         language_fp = os.path.join(quickumls_fp, 'language.flag')
 
         # download stopwords if necessary

--- a/quickumls/core.py
+++ b/quickumls/core.py
@@ -26,7 +26,7 @@ class QuickUMLS(object):
             overlapping_criteria='score', threshold=0.7, window=5,
             similarity_name='jaccard', min_match_length=3,
             accepted_semtypes=constants.ACCEPTED_SEMTYPES,
-            verbose=False):
+            verbose=False, keep_uppercase=False):
         """Instantiate QuickUMLS object
 
             This is the main interface through which text can be processed.
@@ -46,6 +46,12 @@ class QuickUMLS(object):
                 (e.g., "T131", which identifies the type "Hazardous or Poisonous Substance").
                 Defaults to constants.ACCEPTED_SEMTYPES.
             verbose (bool, optional): TODO:??. Defaults to False.
+            keep_uppercase (bool, optional): By default QuickUMLS converts all
+                    uppercase strings to lowercase. This option disables that
+                    functionality, which makes QuickUMLS useful for
+                    distinguishing acronyms from normal words. For this the
+                    database should be installed without the -L option.
+                    Defaults to False.
 
         Raises:
             ValueError: Raises a ValueError if QuickUMLS was installed for a language that is not currently supported TODO: verify this?
@@ -86,6 +92,7 @@ class QuickUMLS(object):
         self.normalize_unicode_flag = os.path.exists(
             os.path.join(quickumls_fp, 'normalize-unicode.flag')
         )
+        self.keep_uppercase = keep_uppercase
 
         language_fp = os.path.join(quickumls_fp, 'language.flag')
 
@@ -131,7 +138,7 @@ class QuickUMLS(object):
                 constants.SPACY_LANGUAGE_MAP.get(self.language_flag, 'xx')
             )
             raise OSError(msg)
-        
+
         self.ss_db = toolbox.SimstringDBReader(
             simstring_fp, similarity_name, threshold
         )
@@ -282,7 +289,7 @@ class QuickUMLS(object):
             # no match is found; so we convert to lowercase;
             # however, this is never needed if the string is lowercased
             # in the step above
-            if not self.to_lowercase_flag and ngram_normalized.isupper():
+            if not self.to_lowercase_flag and ngram_normalized.isupper() and not self.keep_uppercase:
                 ngram_normalized = ngram_normalized.lower()
 
             prev_cui = None

--- a/quickumls/server.py
+++ b/quickumls/server.py
@@ -12,7 +12,8 @@ def run_quickumls_server(opts):
         similarity_name=opts.similarity_name,
         window=opts.window,
         min_match_length=opts.min_match_length,
-        verbose=opts.verbose
+        verbose=opts.verbose,
+        keep_uppercase=opts.keep_uppercase
     )
 
     run_server(matcher, host=opts.host, port=opts.port, buffersize=4096)
@@ -71,7 +72,13 @@ def parse_args():
         '-v', '--verbose', action='store_true',
         help='return verbose information while running'
     )
-
+    ap.add_argument(
+        '-u', '--keep_uppercase', action='store_true',
+        help='By default QuickUMLS converts all uppercase strings to lowercase'
+             '. This option disables that functionality, which makes QuickUMLS '
+             'useful for distinguishing acronyms from normal words. For this '
+             'the database should be installed without the -L option.'
+    )
     return ap.parse_args()
 
 


### PR DESCRIPTION
Hi @soldni thanks for maintaining this tool. I made a small change for my local installation, and thought it would perhaps be useful for others as well.

I ran into an issue when all characters of a medical term were in uppercase. By default, QuickUMLS would convert this term to lowercase. This would then make it difficult to distinguish between the normal word, and the original term in uppercase. For example, the acronym `MAP` for microtubule-associated proteins would be converted to `map`. I added an argument to disable this conversion, resulting in that `MAP` can be more easily identified as microtubule-associated proteins and is not confused with the word `map`.

The added functionality would only work when the database is installed without the `-L` option.