### PR TITLE
fixed spacy language map issue

### DIFF
--- a/quickumls/constants.py
+++ b/quickumls/constants.py
@@ -185,12 +185,12 @@ DOMAIN_SPECIFIC_STOPWORDS = {
 }
 
 SPACY_LANGUAGE_MAP = {
-    'ENG': 'en',
-    'GER': 'de',
-    'SPA': 'es',
-    'POR': 'pt',
-    'FRE': 'fr',
-    'ITA': 'it',
-    'DUT': 'nl',
+    'ENG': 'en_core_web_sm',
+    'GER': 'de_core_news_sm',
+    'SPA': 'es_core_news_sm',
+    'POR': 'pt_core_news_sm',
+    'FRE': 'fr_core_news_sm',
+    'ITA': 'it_core_news_sm',
+    'DUT': 'nl_core_news_sm',
     'XXX': 'xx'
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 leveldb>=0.193
 numpy>=1.8.2
-spacy>=1.6.0
+spacy=3.0.6
 unidecode>=0.4.19
 nltk>=3.3
 quickumls_simstring>=1.1.5r1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 leveldb>=0.193
 numpy>=1.8.2
-spacy==3.0.6
+spacy>=3.0.6
 unidecode>=0.4.19
 nltk>=3.3
 quickumls_simstring>=1.1.5r1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 leveldb>=0.193
 numpy>=1.8.2
-spacy=3.0.6
+spacy==3.0.6
 unidecode>=0.4.19
 nltk>=3.3
 quickumls_simstring>=1.1.5r1


### PR DESCRIPTION
Spacy updated d its language map so that it doesnt work with the shortened language names. I fixed this so the lang_map now works with spacy > 3