### PR TITLE
fixes #74

### DIFF
--- a/quickumls/core.py
+++ b/quickumls/core.py
@@ -445,11 +445,11 @@ class QuickUMLS(object):
         parsed = self.nlp(u'{}'.format(text))
         
         # pass in parsed spacy doc to get concept matches
-        matches = self._match(parsed)
+        matches = self._match(parsed, best_match, ignore_syntax)
 
         return matches
         
-    def _match(self, doc, best_match=True, ignore_syntax=False):
+    def _match(self, doc, best_match, ignore_syntax):
         """Gathers ngram matches given a spaCy document object.
 
         [extended_summary]


### PR DESCRIPTION
Bug: The users choise of the best_match and ignore_syntax parameters is ignored, as it isn't passed down from the match function in core to the _match function.

Fix: the parameters are now passed down from match to _match