### PR TITLE
Add six to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ unidecode>=0.4.19
 nltk>=3.3
 quickumls_simstring>=1.1.5r1
 unqlite>=0.8.1
+six


### PR DESCRIPTION
added six as a requirement. was not installed in a fresh venv during `python setup.py install` but its imported in several modules. not sure what version is required so left off a version restriction for now. at the moment, looks like the latest version is 1.16.0