### PR TITLE
Solve nested entities problems by using SpanCategorizer

### DIFF
--- a/quickumls/spacy_component.py
+++ b/quickumls/spacy_component.py
@@ -62,6 +62,16 @@ class SpacyQuickUMLS(object):
                 # add some custom metadata to the spans
                 span._.similarity = ngram_match_dict['similarity']
                 span._.semtypes = ngram_match_dict['semtypes']
-                doc.ents = list(doc.ents) + [span]
                 
+                # OLD: doc.ents = list(doc.ents) + [span]
+                # Using doc.spans["sc"] (SpanCategorizer) to solve the problem of overlapped tokens in nested NER for spacy.
+                # With doc.spans["sc"], all possible entities are stored without throwing errors.
+                doc.spans["sc"] = list(doc.spans["sc"]) + [span]
+
+        # After storing all possible spans, we filter out overlapping spans before adding them to doc.ents. 
+        # Here we remove overlapping spans using spacy.util.filter_spans 
+        # When spans overlap, the rule is to prefer the first longest span over shorter ones.
+        for span in spacy.util.filter_spans(doc.spans["sc"]):
+            doc.ents = list(doc.ents) + [span]
+
         return doc


### PR DESCRIPTION
Using `doc.spans["sc"]` (SpanCategorizer) to solve the problem of overlapped tokens in nested NER for spacy. By replacing `doc.ents` with `doc.spans["sc"]`, all possible entities are able to be stored without any errors.
After storing all possible spans, we filter out overlapping spans before adding them to `doc.ents`. Here we remove overlapping spans using `spacy.util.filter_spans`. When spans overlap, the rule is to prefer the first longest span over shorter ones.

