### PR TITLE
fix import error: cannot import name 'MEDSPACY_DEFAULT_SPAN_GROUP_NAME'

### DIFF
--- a/quickumls/constants.py
+++ b/quickumls/constants.py
@@ -1,3 +1,5 @@
+MEDSPACY_DEFAULT_SPAN_GROUP_NAME = 'medspacy_spans'
+
 HEADERS_MRCONSO = [
     'cui', 'lat', 'ts', 'lui', 'stt', 'sui', 'ispref', 'aui', 'saui',
     'scui', 'sdui', 'sab', 'tty', 'code', 'str', 'srl', 'suppress', 'cvf'


### PR DESCRIPTION
Bug:
Concurrent installation of medspacy and quickumls results in:
ImportError: cannot import name 'MEDSPACY_DEFAULT_SPAN_GROUP_NAME' from 'quickumls.constants'
when trying to run the first cell of 11a quickumls medspacy notebook.
Comparison with medspacy installation without quickumls installation revealed additional line on constants.py.

Fix:
add MEDSPACY_DEFAULT_SPAN_GROUP_NAME in constants.py